### PR TITLE
docs: add supported Cursor version info (1.2.x) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Forget Cursor Student restrictions and country bans! This revolutionary web-base
 - **User-Friendly Interface**: Clean, modern UI with clear instructions
 - **System Information**: Displays detailed system and Cursor installation info
 
+## ✅ Cursor Compatibility
+
+- Fully compatible with **Cursor IDE version 1.2.x**
+- Functionality tested and optimized for this version
+
 ## Installation
 
 1. **Clone the repository**


### PR DESCRIPTION
Added a new section ## ✅ Cursor Compatibility to the README file, specifying that the tool is fully compatible with Cursor IDE version 1.2.x. This ensures users are aware of which version the reset tool has been tested and optimized for.